### PR TITLE
Add documentation site using Documenter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docs/build/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# LorenzAttractor.jl
+
+This package implements the Lorenz system and provides utilities for plotting
+the well known attractor. It is intended as a minimal example for exploring
+the dynamics of chaotic systems in Julia.
+
+## Features
+
+- In-place equation definition `parameterized_lorenz!`.
+- Helper function `plot_Lorenz_attractor_interpolated` that solves and draws
+  a smooth trajectory.
+- Documentation built with [Documenter.jl](https://juliadocs.github.io/Documenter.jl/).
+
+## Building the Documentation
+
+```bash
+julia --project=docs docs/make.jl
+```
+
+The generated site will be available in `docs/build`.

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+LorenzAttractor = "0e56fec3-077b-4dc7-9864-a59fa6df7bf2"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,12 @@
+using Documenter
+using LorenzAttractor
+
+makedocs(
+    sitename = "LorenzAttractor.jl",
+    modules = [LorenzAttractor],
+    format = Documenter.HTML(),
+    pages = [
+        "Home" => "index.md",
+    ],
+)
+

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,34 @@
+```@meta
+CurrentModule = LorenzAttractor
+```
+
+# LorenzAttractor.jl
+
+`LorenzAttractor.jl` provides a simple implementation of the classic
+Lorenz system together with a convenience function for plotting the
+resulting attractor.
+
+## Installation
+
+```julia
+using Pkg
+Pkg.add(url="https://github.com/your/repo")
+```
+
+## Usage
+
+```julia
+using LorenzAttractor
+
+u0 = [1.0, 0.0, 0.0]
+tspan = (0.0, 20.0)
+p = [10.0, 28.0, 8/3]
+
+plot_Lorenz_attractor_interpolated(u0, tspan, p)
+```
+
+## API
+
+```@autodocs
+Modules = [LorenzAttractor]
+```

--- a/src/LorenzAttractor.jl
+++ b/src/LorenzAttractor.jl
@@ -6,6 +6,13 @@ using DifferentialEquations
 using Plots
 using Interpolations
 
+"""
+    parameterized_lorenz!(du, u, p, t)
+
+Compute the derivatives of the Lorenz system in-place. The state vector
+`u = (x, y, z)` evolves according to the parameters `p = (σ, ρ, β)`.
+The result is written to `du`.
+"""
 function parameterized_lorenz!(du, u, p, t)
     x, y, z = u
     σ, ρ, β = p
@@ -15,6 +22,13 @@ function parameterized_lorenz!(du, u, p, t)
     return nothing
 end
 
+"""
+    plot_Lorenz_attractor_interpolated(u0, tspan, p; N=1000)
+
+Solve the Lorenz equations starting at `u0` over the time span `tspan` and
+return a 3‑D plot of the trajectory. The optional keyword `N` controls the
+number of interpolation points used to smooth the plot.
+"""
 function plot_Lorenz_attractor_interpolated(u0, tspan, p; N=1000)
     prob = ODEProblem(parameterized_lorenz!, u0, tspan, p)
     sol = solve(prob, Tsit5(), saveat=tspan[1] .+ (tspan[2] - tspan[1]) * (0:N) / N)


### PR DESCRIPTION
## Summary
- document the Lorenz attractor functions with docstrings
- add README
- add Documenter.jl configuration with docs/ folder
- ignore generated build directory

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: `julia` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c877d20c8332a9daf70d62c9771c